### PR TITLE
Support stricter projections and filters where applicable, ensure hooks are called with their hookOptions, add support for shouldRun for deleteN and updateN

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongo-collection-hooks",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "",
   "main": "lib/index.js",
   "type": "module",
@@ -37,7 +37,7 @@
     "./es2015/*": "./es2015/*"
   },
   "dependencies": {
-    "mongo-collection-helpers": "^1.0.8"
+    "mongo-collection-helpers": "^1.0.13"
   },
   "devDependencies": {
     "@blastjs/minimongo": "^0.1.0",

--- a/src/abstractCollectionImpl.ts
+++ b/src/abstractCollectionImpl.ts
@@ -1,4 +1,5 @@
 import type { AggregateOptions, AggregationCursor, AnyBulkWriteOperation, BSONSerializeOptions, BulkWriteOptions, BulkWriteResult, ChangeStream, ChangeStreamDocument, ChangeStreamOptions, CollStats, CollStatsOptions, Collection, CommandOperationOptions, CountDocumentsOptions, CountOptions, CreateIndexesOptions, DeleteOptions, DeleteResult, DistinctOptions, Document, DropCollectionOptions, EnhancedOmit, EstimatedDocumentCountOptions, Filter, FindCursor, FindOneAndDeleteOptions, FindOneAndReplaceOptions, FindOneAndUpdateOptions, FindOptions, Hint, IndexDescription, IndexInformationOptions, IndexSpecification, InsertManyResult, InsertOneOptions, InsertOneResult, ListIndexesCursor, ListIndexesOptions, ListSearchIndexesCursor, ListSearchIndexesOptions, ModifyResult, OperationOptions, OptionalUnlessRequiredId, OrderedBulkOperation, ReadConcern, ReadPreference, RenameOptions, ReplaceOptions, SearchIndexDescription, UnorderedBulkOperation, UpdateFilter, UpdateOptions, UpdateResult, WithId, WithoutId, WriteConcern } from "mongodb"
+import { MaybeStrictFilter } from "./events/collectionEvents.js";
 
 export abstract class AbstractHookedCollection<TSchema extends Document> implements Collection<TSchema> {
   #collection: Collection<TSchema>
@@ -105,55 +106,55 @@ export abstract class AbstractHookedCollection<TSchema extends Document> impleme
   }
 
   abstract aggregate<T extends Document = Document>(pipeline?: Document[] | undefined, options?: AggregateOptions | undefined): AggregationCursor<T>;
-  abstract count(filter?: Filter<TSchema> | undefined, options?: CountOptions | undefined): Promise<number>;
+  abstract count(filter?: MaybeStrictFilter<TSchema> | undefined, options?: CountOptions | undefined): Promise<number>;
 
   abstract countDocuments(filter?: Document | undefined, options?: CountDocumentsOptions | undefined): Promise<number>;
 
-  abstract deleteMany(filter?: Filter<TSchema> | undefined, options?: DeleteOptions | undefined): Promise<DeleteResult>;
-  abstract deleteOne(filter?: Filter<TSchema> | undefined, options?: DeleteOptions | undefined): Promise<DeleteResult>;
+  abstract deleteMany(filter?: MaybeStrictFilter<TSchema> | undefined, options?: DeleteOptions | undefined): Promise<DeleteResult>;
+  abstract deleteOne(filter?: MaybeStrictFilter<TSchema> | undefined, options?: DeleteOptions | undefined): Promise<DeleteResult>;
 
   abstract distinct(key: string): Promise<any[]>;
-  abstract distinct(key: string, filter: Filter<TSchema>): Promise<any[]>;
-  abstract distinct(key: string, filter: Filter<TSchema>, options: DistinctOptions): Promise<any[]>;
-  abstract distinct<Key extends keyof WithId<TSchema>>(key: Key, filter: Filter<TSchema>, options: DistinctOptions): Promise<any[]>;
+  abstract distinct(key: string, filter: MaybeStrictFilter<TSchema>): Promise<any[]>;
+  abstract distinct(key: string, filter: MaybeStrictFilter<TSchema>, options: DistinctOptions): Promise<any[]>;
+  abstract distinct<Key extends keyof WithId<TSchema>>(key: Key, filter: MaybeStrictFilter<TSchema>, options: DistinctOptions): Promise<any[]>;
 
   abstract estimatedDocumentCount(options?: EstimatedDocumentCountOptions | undefined): Promise<number>;
 
   abstract find(): FindCursor<WithId<TSchema>>;
-  abstract find(filter: Filter<TSchema>, options?: FindOptions<Document> | undefined): FindCursor<WithId<TSchema>>;
-  abstract find<T extends Document>(filter: Filter<TSchema>, options?: FindOptions<Document> | undefined): FindCursor<T>;
-  abstract find(filter: Filter<TSchema>, options: FindOptions): FindCursor<WithId<TSchema>>;
+  abstract find(filter: MaybeStrictFilter<TSchema>, options?: FindOptions<Document> | undefined): FindCursor<WithId<TSchema>>;
+  abstract find<T extends Document>(filter: MaybeStrictFilter<TSchema>, options?: FindOptions<Document> | undefined): FindCursor<T>;
+  abstract find(filter: MaybeStrictFilter<TSchema>, options: FindOptions): FindCursor<WithId<TSchema>>;
 
   abstract findOne(): Promise<WithId<TSchema> | null>;
-  abstract findOne(filter: Filter<TSchema>): Promise<WithId<TSchema> | null>;
-  abstract findOne(filter: Filter<TSchema>, options: FindOptions<Document>): Promise<WithId<TSchema> | null>;
+  abstract findOne(filter: MaybeStrictFilter<TSchema>): Promise<WithId<TSchema> | null>;
+  abstract findOne(filter: MaybeStrictFilter<TSchema>, options: FindOptions<Document>): Promise<WithId<TSchema> | null>;
   abstract findOne<T = TSchema>(): Promise<T | null>;
-  abstract findOne<T = TSchema>(filter: Filter<TSchema>): Promise<T | null>;
-  abstract findOne<T = TSchema>(filter: Filter<TSchema>, options?: FindOptions<Document> | undefined): Promise<T | null>;
-  abstract findOne(filter: Filter<TSchema>, options: FindOptions): Promise<WithId<TSchema> | null>;
+  abstract findOne<T = TSchema>(filter: MaybeStrictFilter<TSchema>): Promise<T | null>;
+  abstract findOne<T = TSchema>(filter: MaybeStrictFilter<TSchema>, options?: FindOptions<Document> | undefined): Promise<T | null>;
+  abstract findOne(filter: MaybeStrictFilter<TSchema>, options: FindOptions): Promise<WithId<TSchema> | null>;
 
-  abstract findOneAndDelete(filter: Filter<TSchema>, options: FindOneAndDeleteOptions & { includeResultMetadata: true }): Promise<ModifyResult<TSchema>>;
-  abstract findOneAndDelete(filter: Filter<TSchema>, options: FindOneAndDeleteOptions & { includeResultMetadata: false }): Promise<WithId<TSchema> | null>;
-  abstract findOneAndDelete(filter: Filter<TSchema>, options: FindOneAndDeleteOptions): Promise<ModifyResult<TSchema>>;
-  abstract findOneAndDelete(filter: Filter<TSchema>): Promise<ModifyResult<TSchema>>;
-  abstract findOneAndDelete(filter: Filter<TSchema>, options?: FindOneAndDeleteOptions): Promise<WithId<TSchema> | ModifyResult<TSchema> | null>;
+  abstract findOneAndDelete(filter: MaybeStrictFilter<TSchema>, options: FindOneAndDeleteOptions & { includeResultMetadata: true }): Promise<ModifyResult<TSchema>>;
+  abstract findOneAndDelete(filter: MaybeStrictFilter<TSchema>, options: FindOneAndDeleteOptions & { includeResultMetadata: false }): Promise<WithId<TSchema> | null>;
+  abstract findOneAndDelete(filter: MaybeStrictFilter<TSchema>, options: FindOneAndDeleteOptions): Promise<ModifyResult<TSchema>>;
+  abstract findOneAndDelete(filter: MaybeStrictFilter<TSchema>): Promise<ModifyResult<TSchema>>;
+  abstract findOneAndDelete(filter: MaybeStrictFilter<TSchema>, options?: FindOneAndDeleteOptions): Promise<WithId<TSchema> | ModifyResult<TSchema> | null>;
 
-  abstract findOneAndUpdate(filter: Filter<TSchema>, update: UpdateFilter<TSchema>, options: FindOneAndUpdateOptions & { includeResultMetadata: true; }): Promise<ModifyResult<TSchema>>;
-  abstract findOneAndUpdate(filter: Filter<TSchema>, update: UpdateFilter<TSchema>, options: FindOneAndUpdateOptions & { includeResultMetadata: false; }): Promise<WithId<TSchema> | null>;
-  abstract findOneAndUpdate(filter: Filter<TSchema>, update: UpdateFilter<TSchema>, options: FindOneAndUpdateOptions): Promise<WithId<TSchema> | null>;
-  abstract findOneAndUpdate(filter: Filter<TSchema>, update: UpdateFilter<TSchema>): Promise<ModifyResult<TSchema>>;
-  abstract findOneAndUpdate(filter: Filter<TSchema>, update: UpdateFilter<TSchema>, options?: FindOneAndUpdateOptions): Promise<ModifyResult<TSchema> | WithId<TSchema> | null>;
+  abstract findOneAndUpdate(filter: MaybeStrictFilter<TSchema>, update: UpdateFilter<TSchema>, options: FindOneAndUpdateOptions & { includeResultMetadata: true; }): Promise<ModifyResult<TSchema>>;
+  abstract findOneAndUpdate(filter: MaybeStrictFilter<TSchema>, update: UpdateFilter<TSchema>, options: FindOneAndUpdateOptions & { includeResultMetadata: false; }): Promise<WithId<TSchema> | null>;
+  abstract findOneAndUpdate(filter: MaybeStrictFilter<TSchema>, update: UpdateFilter<TSchema>, options: FindOneAndUpdateOptions): Promise<WithId<TSchema> | null>;
+  abstract findOneAndUpdate(filter: MaybeStrictFilter<TSchema>, update: UpdateFilter<TSchema>): Promise<ModifyResult<TSchema>>;
+  abstract findOneAndUpdate(filter: MaybeStrictFilter<TSchema>, update: UpdateFilter<TSchema>, options?: FindOneAndUpdateOptions): Promise<ModifyResult<TSchema> | WithId<TSchema> | null>;
 
-  abstract findOneAndReplace(filter: Filter<TSchema>, replacement: WithoutId<TSchema>, options: FindOneAndReplaceOptions & { includeResultMetadata: true }): Promise<ModifyResult<TSchema>>;
-  abstract findOneAndReplace(filter: Filter<TSchema>, replacement: WithoutId<TSchema>, options: FindOneAndReplaceOptions & { includeResultMetadata: false }): Promise<WithId<TSchema> | null>;
-  abstract findOneAndReplace(filter: Filter<TSchema>, replacement: WithoutId<TSchema>, options: FindOneAndReplaceOptions): Promise<ModifyResult<TSchema>>;
-  abstract findOneAndReplace(filter: Filter<TSchema>, replacement: WithoutId<TSchema>): Promise<ModifyResult<TSchema>>;
-  abstract findOneAndReplace(filter: Filter<TSchema>, replacement: WithoutId<TSchema>, options?: FindOneAndReplaceOptions): Promise<WithId<TSchema> | ModifyResult<TSchema> | null>;
+  abstract findOneAndReplace(filter: MaybeStrictFilter<TSchema>, replacement: WithoutId<TSchema>, options: FindOneAndReplaceOptions & { includeResultMetadata: true }): Promise<ModifyResult<TSchema>>;
+  abstract findOneAndReplace(filter: MaybeStrictFilter<TSchema>, replacement: WithoutId<TSchema>, options: FindOneAndReplaceOptions & { includeResultMetadata: false }): Promise<WithId<TSchema> | null>;
+  abstract findOneAndReplace(filter: MaybeStrictFilter<TSchema>, replacement: WithoutId<TSchema>, options: FindOneAndReplaceOptions): Promise<ModifyResult<TSchema>>;
+  abstract findOneAndReplace(filter: MaybeStrictFilter<TSchema>, replacement: WithoutId<TSchema>): Promise<ModifyResult<TSchema>>;
+  abstract findOneAndReplace(filter: MaybeStrictFilter<TSchema>, replacement: WithoutId<TSchema>, options?: FindOneAndReplaceOptions): Promise<WithId<TSchema> | ModifyResult<TSchema> | null>;
 
   abstract insertMany(docs: OptionalUnlessRequiredId<TSchema>[], options?: BulkWriteOptions | undefined): Promise<InsertManyResult<TSchema>>;
   abstract insertOne(doc: OptionalUnlessRequiredId<TSchema>, options?: InsertOneOptions | undefined): Promise<InsertOneResult<TSchema>>;
-  abstract replaceOne(filter: Filter<TSchema>, replacement: WithoutId<TSchema>, options?: ReplaceOptions | undefined): Promise<Document | UpdateResult<TSchema>>;
-  abstract updateMany(filter: Filter<TSchema>, update: UpdateFilter<TSchema>, options?: UpdateOptions | undefined): Promise<UpdateResult<TSchema>>;
-  abstract updateOne(filter: Filter<TSchema>, update: UpdateFilter<TSchema> | Partial<TSchema>, options?: UpdateOptions | undefined): Promise<UpdateResult<TSchema>>;
+  abstract replaceOne(filter: MaybeStrictFilter<TSchema>, replacement: WithoutId<TSchema>, options?: ReplaceOptions | undefined): Promise<Document | UpdateResult<TSchema>>;
+  abstract updateMany(filter: MaybeStrictFilter<TSchema>, update: UpdateFilter<TSchema>, options?: UpdateOptions | undefined): Promise<UpdateResult<TSchema>>;
+  abstract updateOne(filter: MaybeStrictFilter<TSchema>, update: UpdateFilter<TSchema> | Partial<TSchema>, options?: UpdateOptions | undefined): Promise<UpdateResult<TSchema>>;
 
 }

--- a/src/events/helpersTypes.ts
+++ b/src/events/helpersTypes.ts
@@ -39,7 +39,7 @@ export type BeforeAfterCallbackArgsAndReturn<
     {
       /** The original "thing", e.g. arguments, result, doc, or whatever before any hook was applied */
       [rek in BIM[k]["returnEmitName"] as `${rek}Orig`]: BIM[k] extends { returns: any } ? BIM[k]["emitArgs"][BIM[k]["returnEmitName"]] : never
-    } & BIM[k]["emitArgs"],
+    } & BIM[k]["emitArgs"] & { hookOptions: BIM[k] extends { options: StandardDefineHookOptions } ? BIM[k]["options"] : StandardDefineHookOptions },
     emitArgs: BIM[k]["emitArgs"],
     returns: BIM[k] extends { returns: any } ? BIM[k]["returns"] : never,
     isPromise: BIM[k]["isPromise"],

--- a/src/events/index.ts
+++ b/src/events/index.ts
@@ -1,7 +1,7 @@
 import type {
   Document
 } from "mongodb"
-export { NestedProjectionOfTSchema } from "mongo-collection-helpers";
+export { ProjectionOfTSchema, NestedProjectionOfTSchema, FilterOfTSchema } from "mongo-collection-helpers";
 import { CallbackAndOptionsOfEm, ChainedAwaiatableEventEmitter, ChainedCallbackEntry, ChainedCallbackEventMap, ChainedListenerCallback } from "../awaiatableEventEmitter.js";
 import { SkipDocument } from "./helpersTypes.js";
 import { BeforeAfterErrorCollectionEventDefinitions, CollectionBeforeAfterErrorEventDefinitions, CollectionHookedEventMap } from "./collectionEvents.js";
@@ -67,7 +67,7 @@ export type PartialCallbackMap<K extends keyof EM, EM extends ChainedCallbackEve
 }
 
 
-export type HookedListenerCallback<K extends keyof HEM, HEM extends ChainedCallbackEventMap> = ChainedListenerCallback<K, HEM>
+export type HookedListenerCallback<K extends keyof HEM, HEM extends ChainedCallbackEventMap> = ChainedListenerCallback<HEM, K>
 
 
 type ChainedCallbackEntryWithCaller = ChainedCallbackEntry & { caller: string | undefined };

--- a/test/collection/helpers.js
+++ b/test/collection/helpers.js
@@ -58,14 +58,16 @@ export async function hooksChain(hookName, chainKey, fn, hookResults = ["Hello",
   const { fakeCollection, hookedCollection } = getHookedCollection([{ _id: "test", value: 1 }, { _id: "test2", value: 2 }, { _id: "test3", value: 3 }]);
   hookedCollection.on(hookName, async ({
     [chainKey]: value,
-    [`${chainKey}Orig`]: valueOrig
+    [`${chainKey}Orig`]: valueOrig,
+    hookOptions
   }) => {
     first = performance.now();
     cachedValueOrig = valueOrig;
     assert.deepEqual(valueOrig, value, "In the first hook, the value and orig value match");
+    assert.deepEqual(hookOptions, { name: "test" }, "the hook options were also provided");
     await setTimeout(100);
     return hookResults[0];
-  });
+  }, { name: "test" });
   hookedCollection.on(hookName, async ({
     [chainKey]: value,
     [`${chainKey}Orig`]: valueOrig

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,7 +1,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert";
 
-import { combineProjections, unionOfProjections, isProjectionExclusion } from "../lib/utils.js";
+import { combineProjections, unionOfProjections, isProjectionExclusion } from "mongo-collection-helpers";
 
 
 describe("utils", () => {


### PR DESCRIPTION
Does a few things:

1. Supports the stricter projections and filters provided by mongo-collection-helpers
2. Allows defining a `name` on a hook, which will be passed to the callback - allowing for instrumentation
3. Add support for `shouldRun` hook option for deleteOne, deleteMany, updateOne, updateMany - since these methods do additional DB calls to pull the affected docs `_id`'s.