### PR TITLE
Fix project and map types

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongo-collection-hooks",
-  "version": "0.2.17",
+  "version": "0.2.18",
   "description": "",
   "main": "lib/index.js",
   "type": "module",

--- a/src/hookedFindCursor.ts
+++ b/src/hookedFindCursor.ts
@@ -54,6 +54,10 @@ export class HookedFindCursor<
     return this.#ee;
   }
 
+  project<T extends Document = Document>(value: Document): HookedFindCursor<T, CollectionSchema> {
+    return this.#cursor.project(value) as unknown as HookedFindCursor<T, CollectionSchema>;
+  }
+
 
   filter(filter: Filter<CollectionSchema>): this {
     this.#cursor.filter(filter);
@@ -337,12 +341,12 @@ export class HookedFindCursor<
     );
   }
 
-  map<T>(transform: (doc: TSchema) => T): HookedFindCursor<T> {
+  map<T>(transform: (doc: TSchema) => T): HookedFindCursor<T, CollectionSchema> {
     // this looks weird, but it means you'll get a transform for the first map, but not subsequent ones
     // because map just returns the cursor, `a.map(() => {}); a.map(() => {})` and `a.map(() => {}).map(() => {})` are equivalent
     const _transform = this.#transform;
     this.#transform = undefined;
-    return super.map<T>((doc) => transform(_transform ? _transform(doc) : doc)) as HookedFindCursor<T>;
+    return super.map<T>((doc) => transform(_transform ? _transform(doc) : doc)) as HookedFindCursor<T, CollectionSchema>;
   }
 
   async toArray(): Promise<TSchema[]> {


### PR DESCRIPTION
The type for project and map was subtly wrong - this caused interesting downstream changes related to type inference