### PR TITLE
Fixing SkipDocument chaining and correct arg chaining in after hooks

### DIFF
--- a/src/awaiatableEventEmitter.ts
+++ b/src/awaiatableEventEmitter.ts
@@ -246,10 +246,11 @@ export class ChainedAwaiatableEventEmitter<
 
   async callAwaitableChainWithKey<K extends keyof EM, CK extends string & keyof EM[K]["emitArgs"] & EM[K]["returnEmitName"]> (
     eventName: K,
-    emitArgs: EM[K]["emitArgs"],
+    emitArgs: Omit<EM[K]["emitArgs"], `${CK}Orig`>,
     chainKey: CK,
     options: StandardInvokeHookOptions<EM, K> | undefined,
   ): Promise<EM[K]["returns"]> {
+    // @ts-expect-error chainKey is valid, but externally we want to enforce that the *Orig isn't required, since we set it ourselves
     const origChainedValue = emitArgs[chainKey];
     return this.#callAwaitableChainWithKey(
       eventName,

--- a/src/awaiatableEventEmitter.ts
+++ b/src/awaiatableEventEmitter.ts
@@ -1,5 +1,8 @@
 
 /** These apply to all hooks */
+
+import { SkipDocument } from "./events/helpersTypes.js"
+
 /**
  * @external
  */
@@ -214,6 +217,7 @@ export class ChainedAwaiatableEventEmitter<
     } = emitArgs;
 
     let chainedValue = emitArgs[chainKey];
+    let isSkipped = false;
 
     for (const { listener, options: hookOptions } of listenersWithOptions) {
       if (signal?.aborted) {
@@ -223,12 +227,19 @@ export class ChainedAwaiatableEventEmitter<
         ...remainderOfEmitArgs,
         [chainKey]: chainedValue,
         [origKey]: origChainedValue,
+        ...(isSkipped ? { isSkipped: true } : {}),
         hookOptions
       };
       const listenerResult = await listener(perListenerArgs);
-      if (listenerResult !== undefined) {
+      if (listenerResult !== undefined && listenerResult !== SkipDocument) {
         chainedValue = listenerResult;
       }
+      if (listenerResult === SkipDocument) {
+        isSkipped = true;
+      }
+    }
+    if (isSkipped) {
+      return SkipDocument;
     }
     return chainedValue;
   }
@@ -288,6 +299,7 @@ export class ChainedAwaiatableEventEmitter<
     ...additionalEvents: ExtraEvent<EM, K>[]
   ): Promise<EM[K]["returns"]> {
     let chainedValue = emitArgs[chainKey];
+    let isSkipped = false;
     const origChainedValue = chainedValue;
     for (const eventNameOrObject of [masterEventName, ...additionalEvents]) {
       const eventName = (eventNameOrObject["event"] || eventNameOrObject) as K;
@@ -298,15 +310,22 @@ export class ChainedAwaiatableEventEmitter<
           ...emitArgs,
           ...extraEmitArgs,
           [chainKey]: chainedValue,
+          ...(isSkipped ? { isSkipped: true } : {})
         },
         chainKey,
         origChainedValue,
         this.relevantAwaitableListenersWithOptions(eventName, options),
         options?.signal
       );
-      if (chainedResult !== undefined) {
+      if (chainedResult !== undefined && chainedResult !== SkipDocument) {
         chainedValue = chainedResult;
       }
+      if (chainedResult === SkipDocument) {
+        isSkipped = true;
+      }
+    }
+    if (isSkipped) {
+      return SkipDocument;
     }
     return chainedValue;
   }

--- a/src/events/collectionEvents.ts
+++ b/src/events/collectionEvents.ts
@@ -153,7 +153,8 @@ type UpdateCommon<TSchema extends Document> = {
       mutator?: UpdateFilter<TSchema> | Partial<TSchema>,
       /** In the case of replaceOne calls, this will be the provided replacement - mutex with mutator */
       replacement?: WithoutId<TSchema>
-    }
+    },
+    isSkipped?: true
   } & FullDocument,
   isPromise: true,
 }
@@ -206,7 +207,9 @@ type InsertCommon<TSchema extends Document> = {
   result: InsertOneResult<TSchema> | UpdateResult,
   custom: {
     /** The document to be inserted */
-    doc: OptionalUnlessRequiredId<TSchema>
+    doc: OptionalUnlessRequiredId<TSchema>,
+    docOrig: OptionalUnlessRequiredId<TSchema>,
+    isSkipped?: true
   },
   isPromise: true
 }
@@ -221,7 +224,8 @@ type DeleteCommon<TSchema extends Document> = {
     /** The ID of the document to be deleted */
     _id: InferIdType<TSchema>,
     /** The filter used to identify the document. Originally this will the main filter, but you can return a mutated version per document. It will be combined with the document ID for the final deletion */
-    filter: MaybeStrictFilter<TSchema>
+    filter: MaybeStrictFilter<TSchema>,
+    isSkipped?: true
   },
   isPromise: true
 }

--- a/src/hookedCollection.ts
+++ b/src/hookedCollection.ts
@@ -545,7 +545,7 @@ export class HookedCollection<
               if (hasAfterError) {
                 // TODO: when ordered=true, some inserts may have succeeded.
                 // We'd need to determine the ones that did, call the success
-                await Promise.all(origChainedDocs.map((docOrig, i) => {
+                await Promise.all(origChainedDocs.map(async (docOrig, i) => {
                   let doc = docOrig;
                   let invocationSymbol = Symbol("No Chained Symbol");
                   if (hasBefore) {
@@ -560,23 +560,23 @@ export class HookedCollection<
                     invocationSymbol = beforeSymbol;
                   }
 
-                  this.#ee.callAllAwaitableInParallel(
-                  {
-                    args: [chainedDocs, chainedOptions],
-                    argsOrig,
-                    caller: "insertMany",
-                    doc,
-                    docOrig,
-                    signal: chainedOptions?.signal,
-                    error: e,
-                    invocationSymbol,
-                    parentInvocationSymbol,
-                    thisArg: this
-                  },
-                  undefined,
-                  Events.afterError.insert,
-                  Events.after.insert
-                );
+                  await this.#ee.callAllAwaitableInParallel(
+                    {
+                      args: [chainedDocs, chainedOptions],
+                      argsOrig,
+                      caller: "insertMany",
+                      doc,
+                      docOrig,
+                      signal: chainedOptions?.signal,
+                      error: e,
+                      invocationSymbol,
+                      parentInvocationSymbol,
+                      thisArg: this
+                    },
+                    undefined,
+                    Events.afterError.insert,
+                    Events.after.insert
+                  );
                 }));
               }
               throw e;

--- a/src/hookedCollection.ts
+++ b/src/hookedCollection.ts
@@ -395,7 +395,7 @@ export class HookedCollection<
     // TODO: this is a bit of a hack. It stops us getting typeerrors on things like findOne*
     OIE extends keyof CollectionOnlyBeforeAfterErrorEventDefinitions<TSchema> | keyof BeforeAfterErrorSharedEventDefinitions<TSchema>,
     EA extends HEM[BE]["emitArgs"],
-    OEA extends Omit<EA, "invocationSymbol" | "thisArg" | "signal">
+    OEA extends Omit<EA, "invocationSymbol" | "thisArg" | "signal" | `${(keyof OEA & HEM[BE]["returnEmitName"])}Orig`>
   >(
     internalEvent: IE,
     emitArgs: OEA,
@@ -505,6 +505,7 @@ export class HookedCollection<
             return raceSignal(chainedOptions?.signal, this.#collection.insertMany(chainedDocs, chainedOptions));
           }
           else {
+            const origChainedDocs = chainedDocs;
             const docMap = new Map<OptionalUnlessRequiredId<TSchema>, { invocationSymbol: symbol, doc: OptionalUnlessRequiredId<TSchema> | typeof SkipDocument }>();
             if (hasBefore) {
               chainedDocs = (await Promise.all(chainedDocs.map(async (doc, index) => {
@@ -551,20 +552,28 @@ export class HookedCollection<
               if (hasAfterError) {
                 // TODO: when ordered=true, some inserts may have succeeded.
                 // We'd need to determine the ones that did, call the success
-                await Promise.all(chainedDocs.map((docOrig, i) => {
-                  const { invocationSymbol, doc } = docMap.get(docOrig) || {};
-                  if (!doc || !invocationSymbol) {
-                    throw new Error("Impossible!");
+                await Promise.all(origChainedDocs.map((docOrig, i) => {
+                  let doc = docOrig;
+                  let invocationSymbol = Symbol("No Chained Symbol");
+                  if (hasBefore) {
+                    const { invocationSymbol: beforeSymbol, doc: beforeHookDoc } = docMap.get(docOrig) || {};
+                    if (!beforeHookDoc || !beforeSymbol) {
+                      throw new Error("Impossible!");
+                    }
+                    if (beforeHookDoc === SkipDocument) {
+                      return;
+                    }
+                    doc = beforeHookDoc;
+                    invocationSymbol = beforeSymbol;
                   }
-                  if (doc === SkipDocument) {
-                    return;
-                  }
+
                   this.#ee.callAllAwaitableInParallel(
                   {
                     args: [chainedDocs, chainedOptions],
                     argsOrig,
                     caller: "insertMany",
                     doc,
+                    docOrig,
                     signal: chainedOptions?.signal,
                     error: e,
                     invocationSymbol,
@@ -581,19 +590,26 @@ export class HookedCollection<
             }
             if (hasAfter) {
               const retToUse = await ret;
-              await Promise.all(chainedDocs.map((docOrig, i) => {
-                const { invocationSymbol, doc } = docMap.get(docOrig) || {};
-                if (!doc || !invocationSymbol) {
-                  throw new Error("Impossible!");
-                }
-                if (doc === SkipDocument) {
-                  return;
+              await Promise.all(origChainedDocs.map((docOrig, i) => {
+                let doc = docOrig;
+                let invocationSymbol = Symbol("No Chained Symbol");
+                if (hasBefore) {
+                  const { invocationSymbol: beforeSymbol, doc: beforeHookDoc } = docMap.get(docOrig) || {};
+                  if (!beforeHookDoc || !beforeSymbol) {
+                    throw new Error("Impossible!");
+                  }
+                  if (beforeHookDoc === SkipDocument) {
+                    return;
+                  }
+                  doc = beforeHookDoc;
+                  invocationSymbol = beforeSymbol;
                 }
                 return this.#ee.callAllAwaitableChainWithKey(
                   {
                     caller: "insertMany",
                     args: [chainedDocs, chainedOptions],
                     doc,
+                    docOrig,
                     signal: chainedOptions?.signal,
                     argsOrig: [chainedDocs, chainedOptions],
                     result: {

--- a/src/hookedCollection.ts
+++ b/src/hookedCollection.ts
@@ -3,7 +3,7 @@ import type{
   Document,
   OptionalUnlessRequiredId,
   WithId,
-  // Filter,
+  Filter as BaseMongoFilter,
   UpdateFilter,
   InsertManyResult,
   UpdateResult,
@@ -15,8 +15,6 @@ import type{
   InsertOneResult,
   ModifyResult,
   WriteError,
-  Condition,
-  RootFilterOperators
 } from 'mongodb';
 import { HookedFindCursor, HookedFindCursorOptions } from "./hookedFindCursor.js";
 
@@ -56,11 +54,6 @@ import { maybeParallel } from './maybeParallel.js';
 import { raceSignal } from './raceSignal.js';
 import { DocumentCache } from './documentCache.js';
 import { BeforeAfterCallbackArgsAndReturn, CommonDefinition, ExtractStandardBeforeAfterEventDefinitions, KeysMatching, Merge } from './events/helpersTypes.js';
-
-/** A MongoDB filter can be some portion of the schema or a set of operators @public */
-type Filter<TSchema> = {
-  [P in keyof WithId<TSchema>]?: Condition<WithId<TSchema>[P]>;
-} & RootFilterOperators<TSchema>;
 
 function notUndefined<TValue>(value: TValue | undefined): value is TValue {
   return value !== undefined;
@@ -233,7 +226,7 @@ export class HookedCollection<
       InternalEvents.distinct,
       { args: [key, filter, options] },
       "args",
-      ({ beforeHooksResult: [chainedKey, chainedFilter, chainedOptions] }) => raceSignal(chainedOptions?.signal, this.#collection.distinct(chainedKey, chainedFilter as Filter<TSchema>, chainedOptions)),
+      ({ beforeHooksResult: [chainedKey, chainedFilter, chainedOptions] }) => raceSignal(chainedOptions?.signal, this.#collection.distinct(chainedKey, chainedFilter as BaseMongoFilter<TSchema>, chainedOptions)),
       options
     );
   }
@@ -252,11 +245,11 @@ export class HookedCollection<
         "args",
         async ({ beforeHooksResult: [chainedFilter, chainedOptions] }) => {
           if (chainedFilter && options) {
-            const ret = await raceSignal(options?.signal, this.#collection.findOne<T>(chainedFilter as Filter<TSchema>, chainedOptions));
+            const ret = await raceSignal(options?.signal, this.#collection.findOne<T>(chainedFilter as BaseMongoFilter<TSchema>, chainedOptions));
             return ret && this.#transform(ret);
           }
           if (chainedFilter) {
-            const ret = await raceSignal(options?.signal, this.#collection.findOne<T>(chainedFilter as Filter<TSchema>));
+            const ret = await raceSignal(options?.signal, this.#collection.findOne<T>(chainedFilter as BaseMongoFilter<TSchema>));
             return ret && this.#transform(ret);
           }
           const ret = await raceSignal(options?.signal, this.#collection.findOne<T>());
@@ -276,10 +269,10 @@ export class HookedCollection<
 
   #find<T extends Document = TSchema>(filter?: MaybeStrictFilter<TSchema>, options?: AmendedFindOptions<TSchema>): FindCursor<T> {
     if (filter && options) {
-      return this.#collection.find<T>(filter as Filter<TSchema>, options);
+      return this.#collection.find<T>(filter as BaseMongoFilter<TSchema>, options);
     }
     else if (filter) {
-      return this.#collection.find<T>(filter as Filter<TSchema>);
+      return this.#collection.find<T>(filter as BaseMongoFilter<TSchema>);
     }
     return this.#collection.find() as unknown as FindCursor<T>;
   }
@@ -761,7 +754,7 @@ export class HookedCollection<
         return null;
       }
     } : this.#collection.find<{ _id: any }>(
-      beforeEmitArgs.args[0] as Filter<TSchema>,
+      beforeEmitArgs.args[0] as BaseMongoFilter<TSchema>,
       {
         projection: isCacheWarmed ? beforeProjection : { _id: 1 },
         limit,
@@ -788,7 +781,7 @@ export class HookedCollection<
         if (isCacheWarmed) {
           beforeDocumentCache.setDocument(nextItem._id, nextItem as unknown as WithId<TSchema>);
         }
-        let chainedFilter: Filter<TSchema> | typeof SkipDocument = beforeEmitArgs.filter as Filter<TSchema>;
+        let chainedFilter: BaseMongoFilter<TSchema> | typeof SkipDocument = beforeEmitArgs.filter as BaseMongoFilter<TSchema>;
         try {
           chainedFilter = (await this.#ee.callExplicitAwaitableListenersChainWithKey(
             Events.before.delete,
@@ -802,7 +795,7 @@ export class HookedCollection<
             "filter",
             beforeListenersWithOptions,
             invocationOptions?.signal
-          )) as Filter<TSchema> | typeof SkipDocument;
+          )) as BaseMongoFilter<TSchema> | typeof SkipDocument;
         }
         catch (error) {
           return {
@@ -1015,7 +1008,7 @@ export class HookedCollection<
         return null;
       }
     } : this.#collection.find<{ _id: any }>(
-      beforeEmitArgs.args[0] as Filter<TSchema>,
+      beforeEmitArgs.args[0] as BaseMongoFilter<TSchema>,
       {
         projection: isCacheWarmed ? beforeProjection : { _id: 1 },
         limit
@@ -1044,19 +1037,19 @@ export class HookedCollection<
             if (caller === "replaceOne") {
               return {
                 type: "UpdateResult",
-                result: await raceSignal(invocationOptions?.signal, this.#collection.replaceOne(args[0] as Filter<TSchema>, args[1], args[2])) as UpdateResult<TSchema>
+                result: await raceSignal(invocationOptions?.signal, this.#collection.replaceOne(args[0] as BaseMongoFilter<TSchema>, args[1], args[2])) as UpdateResult<TSchema>
               };
             }
             else if (caller === "updateOne") {
               return {
                 type: "UpdateResult",
-                result: await raceSignal(invocationOptions?.signal, this.#collection.updateOne(args[0] as Filter<TSchema>, args[1], args[2]))
+                result: await raceSignal(invocationOptions?.signal, this.#collection.updateOne(args[0] as BaseMongoFilter<TSchema>, args[1], args[2]))
               };
             }
             else if (caller === "updateMany") {
               return {
                 type: "UpdateResult",
-                result: await raceSignal(invocationOptions?.signal, this.#collection.updateMany(args[0] as Filter<TSchema>, args[1], args[2]))
+                result: await raceSignal(invocationOptions?.signal, this.#collection.updateMany(args[0] as BaseMongoFilter<TSchema>, args[1], args[2]))
               };
             }
             else if (caller === "findOneAndUpdate") {
@@ -1065,18 +1058,18 @@ export class HookedCollection<
                 if (args[2].includeResultMetadata === false) {
                   return {
                     type: "Document",
-                    result: await raceSignal(invocationOptions?.signal, this.#collection.findOneAndUpdate(args[0] as Filter<TSchema>, args[1], { ...args[2], includeResultMetadata: false }))
+                    result: await raceSignal(invocationOptions?.signal, this.#collection.findOneAndUpdate(args[0] as BaseMongoFilter<TSchema>, args[1], { ...args[2], includeResultMetadata: false }))
                   };
                 }
                 return {
                   // CAREFUL - apparently this defaults to true NOW, but will default to false in a future release... fun
                   type: "ModifyResult",
-                  result: await raceSignal(invocationOptions?.signal, this.#collection.findOneAndUpdate(args[0] as Filter<TSchema>, args[1], args[2]))
+                  result: await raceSignal(invocationOptions?.signal, this.#collection.findOneAndUpdate(args[0] as BaseMongoFilter<TSchema>, args[1], args[2]))
                 };
               }
               return {
                 type: "ModifyResult",
-                result: await raceSignal(invocationOptions?.signal, this.#collection.findOneAndUpdate(args[0] as Filter<TSchema>, args[1]))
+                result: await raceSignal(invocationOptions?.signal, this.#collection.findOneAndUpdate(args[0] as BaseMongoFilter<TSchema>, args[1]))
               };
             }
             else if (caller === "findOneAndReplace") {
@@ -1085,18 +1078,18 @@ export class HookedCollection<
                 if (args[2].includeResultMetadata === false) {
                   return {
                     type: "Document",
-                    result: await raceSignal(invocationOptions?.signal, this.#collection.findOneAndReplace(args[0] as Filter<TSchema>, args[1], { ...args[2], includeResultMetadata: false }))
+                    result: await raceSignal(invocationOptions?.signal, this.#collection.findOneAndReplace(args[0] as BaseMongoFilter<TSchema>, args[1], { ...args[2], includeResultMetadata: false }))
                   };
                 }
                 return {
                   // CAREFUL - apparently this defaults to true NOW, but will default to false in a future release... fun
                   type: "ModifyResult",
-                  result: await raceSignal(invocationOptions?.signal, this.#collection.findOneAndReplace(args[0] as Filter<TSchema>, args[1], args[2]))
+                  result: await raceSignal(invocationOptions?.signal, this.#collection.findOneAndReplace(args[0] as BaseMongoFilter<TSchema>, args[1], args[2]))
                 };
               }
               return {
                 type: "ModifyResult",
-                result: await raceSignal(invocationOptions?.signal, this.#collection.findOneAndReplace(args[0] as Filter<TSchema>, args[1]))
+                result: await raceSignal(invocationOptions?.signal, this.#collection.findOneAndReplace(args[0] as BaseMongoFilter<TSchema>, args[1]))
               };
             }
             throw new Error("Unrecognized caller");
@@ -1349,14 +1342,14 @@ export class HookedCollection<
                 type: "UpdateResult",
                 result: await raceSignal(options?.signal, this.#collection.replaceOne(
                   // @ts-expect-error
-                  chainedFilter?._id === _id ? chainedFilter as Filter<TSchema> : { $and: [chainedFilter as Filter<TSchema>, { _id }] },
+                  chainedFilter?._id === _id ? chainedFilter as BaseMongoFilter<TSchema> : { $and: [chainedFilter as BaseMongoFilter<TSchema>, { _id }] },
                   chainedReplacement as WithoutId<TSchema>,
                   args[2]
                 )) as UpdateResult // it's only a document when explain: true, and I can't see how to make that the case.
               };
             },
             async (attemptedIds) => {
-              let selector = args[0] as Filter<TSchema>;
+              let selector = args[0] as BaseMongoFilter<TSchema>;
               if (attemptedIds?.length) {
                 // @ts-expect-error
                 selector = {
@@ -1395,7 +1388,7 @@ export class HookedCollection<
     const wantsIds = [...beforeListenersWithOptions, ...afterListenersWithOptions, ...afterSuccessListenersWithOptions].filter(({ options: hookOptions }) => hookOptions?.["includeId"] || hookOptions?.["includeIds"] ).length;
     let ids: InferIdType<TSchema>[] | undefined;
     if (wantsIds) {
-      ids = (await raceSignal(options?.signal, this.#collection.find(filter as Filter<TSchema>, { projection: { _id: 1 }, ...(operation === "updateOne" ? { limit: 1 } : {}) }).toArray())).map(({ _id }) => _id);
+      ids = (await raceSignal(options?.signal, this.#collection.find(filter as BaseMongoFilter<TSchema>, { projection: { _id: 1 }, ...(operation === "updateOne" ? { limit: 1 } : {}) }).toArray())).map(({ _id }) => _id);
     }
     const argsOrig = [filter, mutator, options] as const;
     const invocationSymbol = Symbol(operation);
@@ -1467,7 +1460,7 @@ export class HookedCollection<
               }
             };
           }
-          let selector = chainedArgs[0] as Filter<TSchema>;
+          let selector = chainedArgs[0] as BaseMongoFilter<TSchema>;
           if (attemptedIds?.length) {
             if (selector._id) {
               // TODO: this'll work for primatives only
@@ -1587,7 +1580,7 @@ export class HookedCollection<
     let ids: InferIdType<TSchema>[] | undefined;
     if (wantsIds) {
       options?.signal?.throwIfAborted();
-      ids = (await raceSignal(options?.signal, this.#collection.find(filter as Filter<TSchema>, { projection: { _id: 1 }, ...(operation === "deleteOne" ? { limit: 1 } : {}) }).toArray())).map(({ _id }) => _id);
+      ids = (await raceSignal(options?.signal, this.#collection.find(filter as BaseMongoFilter<TSchema>, { projection: { _id: 1 }, ...(operation === "deleteOne" ? { limit: 1 } : {}) }).toArray())).map(({ _id }) => _id);
     }
     const argsOrig = [filter, options] as const;
     const invocationSymbol = Symbol(operation);
@@ -1638,7 +1631,7 @@ export class HookedCollection<
           };
         },
         async (attemptedIds) => {
-          let selector = chainedArgs[0] as Filter<TSchema>;
+          let selector = chainedArgs[0] as BaseMongoFilter<TSchema>;
           if (operation === "deleteOne" && attemptedIds?.length) {
             return {
               type: "DeleteResult",
@@ -1780,7 +1773,7 @@ export class HookedCollection<
           args: [filter, options]
         },
         "args",
-        ({ beforeHooksResult: [chainedFilter, chainedOptions] }) => raceSignal(chainedOptions?.signal, this.#collection.count(chainedFilter as Filter<TSchema>, chainedOptions)),
+        ({ beforeHooksResult: [chainedFilter, chainedOptions] }) => raceSignal(chainedOptions?.signal, this.#collection.count(chainedFilter as BaseMongoFilter<TSchema>, chainedOptions)),
         options,
         {
           event: InternalEvents["count*"],
@@ -1834,7 +1827,7 @@ export class HookedCollection<
           args: [filter, options]
         },
         "args",
-        ({ beforeHooksResult: [chainedFilter, chainedOptions] }) => raceSignal(chainedOptions?.signal, this.#collection.countDocuments(chainedFilter as Filter<TSchema>, chainedOptions)),
+        ({ beforeHooksResult: [chainedFilter, chainedOptions] }) => raceSignal(chainedOptions?.signal, this.#collection.countDocuments(chainedFilter as BaseMongoFilter<TSchema>, chainedOptions)),
         options,
         {
           event: InternalEvents["count*"],
@@ -1902,7 +1895,7 @@ export class HookedCollection<
               if (chainedOptions) {
                 const result = await raceSignal(chainedOptions?.signal, this.#collection.findOneAndDelete(
                   // @ts-expect-error
-                  twiceChainedFilter?._id === _id ? twiceChainedFilter as Filter<TSchema> : { $and: [{ _id }, twiceChainedFilter as Filter<TSchema>] },
+                  twiceChainedFilter?._id === _id ? twiceChainedFilter as BaseMongoFilter<TSchema> : { $and: [{ _id }, twiceChainedFilter as BaseMongoFilter<TSchema>] },
                   chainedOptions
                 ));
 
@@ -1919,7 +1912,7 @@ export class HookedCollection<
               }
               const result = await this.#collection.findOneAndDelete(
                 // @ts-expect-error
-                twiceChainedFilter?._id === _id ? twiceChainedFilter as Filter<TSchema> : { $and: [{ _id }, twiceChainedFilter as Filter<TSchema>] }
+                twiceChainedFilter?._id === _id ? twiceChainedFilter as BaseMongoFilter<TSchema> : { $and: [{ _id }, twiceChainedFilter as BaseMongoFilter<TSchema>] }
               );
               result.value = result.value && this.#transform(result.value);
               return {
@@ -1930,7 +1923,7 @@ export class HookedCollection<
             async () => {
               let result: ModifyResult<TSchema> | WithId<TSchema> | null;
               if (chainedOptions) {
-                result = await raceSignal(chainedOptions?.signal, this.#collection.findOneAndDelete(chainedFilter as Filter<TSchema>, chainedOptions));
+                result = await raceSignal(chainedOptions?.signal, this.#collection.findOneAndDelete(chainedFilter as BaseMongoFilter<TSchema>, chainedOptions));
                 if (chainedOptions.includeResultMetadata === false) {
                   result = result && this.#transform(result);
                 }
@@ -1939,7 +1932,7 @@ export class HookedCollection<
                 }
               }
               else {
-                result = await this.#collection.findOneAndDelete(chainedFilter as Filter<TSchema>);
+                result = await this.#collection.findOneAndDelete(chainedFilter as BaseMongoFilter<TSchema>);
                 result.value = result.value && this.#transform(result.value);
               }
               return {
@@ -2029,7 +2022,7 @@ export class HookedCollection<
               if (chainedOptions) {
                 const result = await raceSignal(chainedOptions?.signal, this.#collection.findOneAndUpdate(
                   // @ts-expect-error
-                  chainedFilterMutator.filter?._id === _id ? chainedFilterMutator.filter as Filter<TSchema> : { $and: [{ _id }, chainedFilterMutator.filter as Filter<TSchema>] },
+                  chainedFilterMutator.filter?._id === _id ? chainedFilterMutator.filter as BaseMongoFilter<TSchema> : { $and: [{ _id }, chainedFilterMutator.filter as BaseMongoFilter<TSchema>] },
                   chainedFilterMutator.mutator,
                   chainedOptions
                 ));
@@ -2046,7 +2039,7 @@ export class HookedCollection<
               }
               const result = await this.#collection.findOneAndUpdate(
                 // @ts-expect-error
-                chainedFilterMutator.filter?._id === _id ? chainedFilterMutator.filter as Filter<TSchema> : { $and: [{ _id }, chainedFilterMutator.filter as Filter<TSchema>] },
+                chainedFilterMutator.filter?._id === _id ? chainedFilterMutator.filter as BaseMongoFilter<TSchema> : { $and: [{ _id }, chainedFilterMutator.filter as BaseMongoFilter<TSchema>] },
                 chainedFilterMutator.mutator
               );
               result.value = result.value && this.#transform(result.value);
@@ -2059,7 +2052,7 @@ export class HookedCollection<
             async () => {
               let result;
               if (chainedOptions) {
-                result = await raceSignal(chainedOptions?.signal, this.#collection.findOneAndUpdate(chainedFilter as Filter<TSchema>, chainedUpdate, chainedOptions));
+                result = await raceSignal(chainedOptions?.signal, this.#collection.findOneAndUpdate(chainedFilter as BaseMongoFilter<TSchema>, chainedUpdate, chainedOptions));
                 if (chainedOptions.includeResultMetadata === false) {
                   result = result && this.#transform(result);
                 }
@@ -2068,7 +2061,7 @@ export class HookedCollection<
                 }
               }
               else {
-                result = await this.#collection.findOneAndUpdate(chainedFilter as Filter<TSchema>, chainedUpdate);
+                result = await this.#collection.findOneAndUpdate(chainedFilter as BaseMongoFilter<TSchema>, chainedUpdate);
                 result.value = result.value && this.#transform(result.value);
               }
               return {
@@ -2158,7 +2151,7 @@ export class HookedCollection<
               if (chainedOptions) {
                 const result = await raceSignal(chainedOptions?.signal, this.#collection.findOneAndReplace(
                   // @ts-expect-error
-                  chainedFilterMutator.filter?._id === _id ? chainedFilterMutator.filter as Filter<TSchema> : { $and: [{ _id }, chainedFilterMutator.filter as Filter<TSchema>] },
+                  chainedFilterMutator.filter?._id === _id ? chainedFilterMutator.filter as BaseMongoFilter<TSchema> : { $and: [{ _id }, chainedFilterMutator.filter as BaseMongoFilter<TSchema>] },
                   chainedFilterMutator.replacement,
                   chainedOptions
                 ))
@@ -2175,7 +2168,7 @@ export class HookedCollection<
               }
               const result = await this.#collection.findOneAndReplace(
                 // @ts-expect-error
-                chainedFilterMutator.filter?._id === _id ? chainedFilterMutator.filter as Filter<TSchema> : { $and: [{ _id }, chainedFilterMutator.filter as Filter<TSchema>] },
+                chainedFilterMutator.filter?._id === _id ? chainedFilterMutator.filter as BaseMongoFilter<TSchema> : { $and: [{ _id }, chainedFilterMutator.filter as BaseMongoFilter<TSchema>] },
                 chainedFilterMutator.replacement
               );
               result.value = result.value && this.#transform(result.value);
@@ -2188,7 +2181,7 @@ export class HookedCollection<
             async () => {
               let result;
               if (chainedOptions) {
-                result = await raceSignal(chainedOptions?.signal, this.#collection.findOneAndReplace(chainedFilter as Filter<TSchema>, chainedReplacement, chainedOptions));
+                result = await raceSignal(chainedOptions?.signal, this.#collection.findOneAndReplace(chainedFilter as BaseMongoFilter<TSchema>, chainedReplacement, chainedOptions));
                 if (chainedOptions.includeResultMetadata === false) {
                   result = result && this.#transform(result);
                 }
@@ -2197,7 +2190,7 @@ export class HookedCollection<
                 }
               }
               else {
-                result = await this.#collection.findOneAndReplace(chainedFilter as Filter<TSchema>, chainedReplacement);
+                result = await this.#collection.findOneAndReplace(chainedFilter as BaseMongoFilter<TSchema>, chainedReplacement);
                 result.value = result.value && this.#transform(result.value);
               }
               return {

--- a/src/hookedFindCursor.ts
+++ b/src/hookedFindCursor.ts
@@ -67,6 +67,7 @@ export class HookedFindCursor<
   }
 
   addFilter(filter: Filter<CollectionSchema>) {
+    // @ts-expect-error I just can't with mongo's freaking types - it doesn't like something about WithId<Schema>
     return this.filter({
       $and: [this.#filter as Filter<CollectionSchema>, filter]
     });

--- a/src/tryCatchEmit.ts
+++ b/src/tryCatchEmit.ts
@@ -130,7 +130,11 @@ export function getTryCatch<
             ...(argsOrig && { argsOrig }),
             ...(result !== undefined && { result }),
             ...(invocationOptions?.signal && { signal: invocationOptions?.signal }),
-            ...beforeAfterEmitArgs
+            ...beforeAfterEmitArgs,
+            ...(chainArgsKey && chainArgsKey !== "args" ? {
+              [`${chainArgsKey}Orig`]: beforeAfterEmitArgs[chainArgsKey],
+              [chainArgsKey]: chainedArgs
+            } : {}),
           },
           "result",
           // @ts-expect-error there's an underlying assumption that the invocationOptions provided will work for the event and the additional events (e.g., before.cursor.execute and before.find.cursor.execute)
@@ -153,7 +157,12 @@ export function getTryCatch<
             ...(argsOrig && { argsOrig }),
             ...(result !== undefined && { result }),
             ...(invocationOptions?.signal && { signal: invocationOptions?.signal }),
-            ...beforeAfterEmitArgs
+            ...beforeAfterEmitArgs,
+            ...(chainArgsKey && chainArgsKey !== "args" ? {
+              [`${chainArgsKey}Orig`]: beforeAfterEmitArgs[chainArgsKey],
+              [chainArgsKey]: chainedArgs
+            } : {}),
+
           },
           // @ts-expect-error there's an underlying assumption that the invocationOptions provided will work for the event and the additional events (e.g., before.cursor.execute and before.find.cursor.execute)
           invocationOptions,
@@ -176,7 +185,11 @@ export function getTryCatch<
             ...(invocationOptions?.signal && { signal: invocationOptions?.signal }),
             error: e,
             thisArg: beforeAfterEmitArgs["thisArg"],
-            ...beforeAfterEmitArgs
+            ...beforeAfterEmitArgs,
+            ...(chainArgsKey && chainArgsKey !== "args" ? {
+              [`${chainArgsKey}Orig`]: beforeAfterEmitArgs[chainArgsKey],
+              [chainArgsKey]: chainedArgs
+            } : {}),
           },
           // @ts-expect-error there's an underlying assumption that the invocationOptions provided will work for the event and the additional events (e.g., before.cursor.execute and before.find.cursor.execute)
           invocationOptions,

--- a/test/collection/delete.js
+++ b/test/collection/delete.js
@@ -69,6 +69,41 @@ export function deleteTests(oneOrMany) {
       assert.deepEqual(result, { deletedCount: 0, acknowledged: false });
     });
 
+    it("Should skip documents correctly when multiple hooks are chained, even if a later hook returns a non-SkipDocument value", async () => {
+      const { hookedCollection } = getHookedCollection([{ _id: "test" }]);
+      const seenFilters = [];
+      hookedCollection.on("before.delete", ({ filter }) => {
+        seenFilters.push({ hook: "A", filter });
+        return { ...filter, a: 1 };
+      });
+      hookedCollection.on("before.delete", ({ filter }) => {
+        seenFilters.push({ hook: "B", filter });
+        return SkipDocument;
+      });
+      hookedCollection.on("before.delete", ({ filter, isSkipped }) => {
+        seenFilters.push({ hook: "C", filter, isSkipped });
+        return { ...filter, c: 1 };
+      });
+      hookedCollection.on("before.delete", ({ filter, isSkipped }) => {
+        seenFilters.push({ hook: "D", filter, isSkipped });
+      });
+      const afterDeleteMock = mock.fn();
+      hookedCollection.on("after.delete.success", afterDeleteMock);
+
+      const result = await hookedCollection[oneOrMany]({ _id: "test" });
+
+      assert.strictEqual(seenFilters.length, 4, "All four before.delete hooks should run");
+      assert.deepEqual(seenFilters[0].filter, { _id: "test" }, "Hook A receives the original filter");
+      assert.deepEqual(seenFilters[1].filter, { _id: "test", a: 1 }, "Hook B receives the filter returned by Hook A");
+      assert.deepEqual(seenFilters[2].filter, { _id: "test", a: 1 }, "Hook C must not receive SkipDocument; it receives the previous chained filter");
+      assert.deepEqual(seenFilters[3].filter, { _id: "test", a: 1, c: 1 }, "Hook D receives the filter returned by Hook C even though Hook B returned SkipDocument");
+      assert.deepEqual(seenFilters[2].isSkipped, true, "Hook C isSkipped");
+      assert.deepEqual(seenFilters[3].isSkipped, true, "Hook D isSkipped");
+
+      assert.strictEqual(afterDeleteMock.mock.callCount(), 0, "after.delete.success must not run when the document was skipped");
+      assert.deepEqual(result, { deletedCount: 0, acknowledged: false }, "The skip is respected even though a later hook returned a non-SkipDocument value");
+    });
+
     it("Should correctly provide the previous document in the after hook", async () => {
       const { hookedCollection } = getHookedCollection([{ _id: "test" }, { _id: "test2" }]);
       const afterDeleteMock = mock.fn();
@@ -82,6 +117,26 @@ export function deleteTests(oneOrMany) {
       else {
         assert.deepEqual(result, { deletedCount: 1, acknowledged: true });
       }
+    });
+
+    it("after.* hooks should fire (success and error) when no before.* hooks are present", async () => {
+      const perDocMethod = oneOrMany === "findOneAndDelete" ? "findOneAndDelete" : "deleteOne";
+
+      const { hookedCollection: hcOk } = getHookedCollection([{ _id: "test" }]);
+      const okAfterDelete = mock.fn();
+      hcOk.on("after.delete.success", okAfterDelete);
+      hcOk.on("after.delete.error", () => assert.fail("after.delete.error must not fire on success"));
+      await hcOk[oneOrMany]({ _id: "test" });
+      assert.strictEqual(okAfterDelete.mock.callCount(), 1, "after.delete.success fires without before hooks");
+
+      const { hookedCollection: hcErr, fakeCollection: fcErr } = getHookedCollection([{ _id: "test" }]);
+      mock.method(fcErr, perDocMethod, () => { throw new Error("BAD DELETE"); });
+      const errAfterDelete = mock.fn();
+      hcErr.on("after.delete.error", errAfterDelete);
+      hcErr.on("after.delete.success", () => assert.fail("after.delete.success must not fire on error"));
+      await assert.rejects(() => hcErr[oneOrMany]({ _id: "test" }));
+      assert.strictEqual(errAfterDelete.mock.callCount(), 1, "after.delete.error fires without before hooks");
+      assert.match(errAfterDelete.mock.calls[0].arguments[0].error.message, /BAD DELETE/);
     });
   });
 }

--- a/test/collection/index.js
+++ b/test/collection/index.js
@@ -20,7 +20,7 @@ import { defineChangeArgs } from "./changeArgs.js";
 import { defineInstrument } from "./instrument.js";
 import { defineExtendedTests } from "./extended.js";
 
-describe.only("collection", () => {
+describe("collection", () => {
   defineInsertOne();
   defineInsertMany();
   defineDeleteOne();

--- a/test/collection/index.js
+++ b/test/collection/index.js
@@ -20,7 +20,7 @@ import { defineChangeArgs } from "./changeArgs.js";
 import { defineInstrument } from "./instrument.js";
 import { defineExtendedTests } from "./extended.js";
 
-describe("collection", () => {
+describe.only("collection", () => {
   defineInsertOne();
   defineInsertMany();
   defineDeleteOne();

--- a/test/collection/insertMany.js
+++ b/test/collection/insertMany.js
@@ -6,7 +6,7 @@ import { assertImplements } from "../helpers.js";
 
 
 export function defineInsertMany() {
-  describe("insertMany", () => {
+  describe.only("insertMany", () => {
     it("should pass the options between before hooks correctly", async () => {
       const result = await hooksChain(
         "before.insertMany",
@@ -131,6 +131,100 @@ export function defineInsertMany() {
       const result = await hookedCollection.insertMany([{ _id: "test" }, { _id: "test2" }]);
       assert.deepEqual(result, { acknowledged: true, insertedIds: { 0: "test2" }, insertedCount: 1 });
       assert.strictEqual(afterInsertMock.mock.callCount(), 1, "Should have only called after.insert for one doc");
+    });
+
+    it("Should skip documents correctly when multiple hooks are chained, even if a later hook returns a non-SkipDocument value", async () => {
+      const { hookedCollection } = getHookedCollection();
+      const seenByHook = { A: [], B: [], C: [], D: [] };
+      hookedCollection.on("before.insert", ({ doc, isSkipped }) => {
+        seenByHook.A.push({doc, isSkipped});
+        return { ...doc, a: 1 };
+      });
+      hookedCollection.on("before.insert", ({ doc, isSkipped }) => {
+        seenByHook.B.push({doc, isSkipped});
+        if (doc._id === "skipMe") {
+          return SkipDocument;
+        }
+      });
+      hookedCollection.on("before.insert", ({ doc, isSkipped }) => {
+        seenByHook.C.push({doc, isSkipped});
+        return { ...doc, c: 1 };
+      });
+      hookedCollection.on("before.insert", ({ doc, isSkipped }) => {
+        seenByHook.D.push({doc, isSkipped});
+      });
+      const afterInsertMock = mock.fn();
+      hookedCollection.on("after.insert.success", afterInsertMock);
+      const result = await hookedCollection.insertMany([{ _id: "skipMe" }, { _id: "keepMe" }]);
+
+      assert.strictEqual(seenByHook.A.length, 2, "Hook A runs for every doc");
+      assert.strictEqual(seenByHook.B.length, 2, "Hook B runs for every doc");
+      assert.strictEqual(seenByHook.C.length, 2, "Hook C runs for every doc, including the one Hook B asked to skip");
+      assert.strictEqual(seenByHook.D.length, 2, "Hook D runs for every doc, including the one Hook B asked to skip");
+
+      const skipMeAtC = seenByHook.C.find(d => d.doc._id === "skipMe");
+      const skipMeAtD = seenByHook.D.find(d => d.doc._id === "skipMe");
+      assert.deepEqual(skipMeAtC, { doc: { _id: "skipMe", a: 1 }, isSkipped: true }, "Hook C must not receive SkipDocument for the skipped doc; it receives the previous chained value");
+      assert.deepEqual(skipMeAtD, { doc: { _id: "skipMe", a: 1, c: 1 }, isSkipped: true }, "Hook D receives the value returned by Hook C even though Hook B returned SkipDocument");
+
+      assert.deepEqual(result, { acknowledged: true, insertedIds: { 0: "keepMe" }, insertedCount: 1 }, "Only the non-skipped doc is inserted");
+      assert.strictEqual(afterInsertMock.mock.callCount(), 1, "after.insert.success runs only for the non-skipped doc");
+      assert.deepEqual(afterInsertMock.mock.calls[0].arguments[0].doc, { _id: "keepMe", a: 1, c: 1 }, "The non-skipped doc still flows through every transforming hook");
+    });
+
+    it.only("after.* hooks should fire (success and error) when no before.* hooks are present", async () => {
+      const { hookedCollection: hcOk } = getHookedCollection();
+      const okAfterInsert = mock.fn();
+      const okAfterInsertMany = mock.fn();
+      hcOk.on("after.insert.success", okAfterInsert);
+      hcOk.on("after.insertMany.success", okAfterInsertMany);
+      hcOk.on("after.insert.error", () => assert.fail("after.insert.error must not fire on success"));
+      hcOk.on("after.insertMany.error", () => assert.fail("after.insertMany.error must not fire on success"));
+      await hcOk.insertMany([{ _id: "ok1" }, { _id: "ok2" }]);
+      assert.strictEqual(okAfterInsert.mock.callCount(), 2, "after.insert.success fires once per doc without before hooks");
+      assert.strictEqual(okAfterInsertMany.mock.callCount(), 1, "after.insertMany.success fires without before hooks");
+
+      const { hookedCollection: hcErr, fakeCollection: fcErr } = getHookedCollection();
+      mock.method(fcErr, "insertMany", () => { throw new Error("BAD INSERT MANY"); });
+      const errAfterInsert = mock.fn();
+      const errAfterInsertMany = mock.fn();
+      hcErr.on("after.insert.error", errAfterInsert);
+      hcErr.on("after.insertMany.error", errAfterInsertMany);
+      hcErr.on("after.insert.success", () => assert.fail("after.insert.success must not fire on error"));
+      hcErr.on("after.insertMany.success", () => assert.fail("after.insertMany.success must not fire on error"));
+      await assert.rejects(() => hcErr.insertMany([{ _id: "fail1" }, { _id: "fail2" }]), /BAD INSERT MANY/);
+      assert.strictEqual(errAfterInsert.mock.callCount(), 2, "after.insert.error fires once per doc without before hooks");
+      assert.strictEqual(errAfterInsertMany.mock.callCount(), 1, "after.insertMany.error fires without before hooks");
+    });
+
+    it("after.insert hooks fire correctly (success and error) when before.insert returns a totally new object", async () => {
+      const { hookedCollection: hcOk, fakeCollection: fcOk } = getHookedCollection();
+      const mockInsertManyOk = mock.method(fcOk, "insertMany");
+      hcOk.on("before.insert", ({ doc }) => ({ _id: `${doc._id}-new`, transformed: true }));
+      const okAfterInsert = mock.fn();
+      hcOk.on("after.insert.success", okAfterInsert);
+      hcOk.on("after.insert.error", () => assert.fail("after.insert.error must not fire on success"));
+
+      const result = await hcOk.insertMany([{ _id: "first" }, { _id: "second" }]);
+      assert.deepEqual(result, { acknowledged: true, insertedIds: { 0: "first-new", 1: "second-new" }, insertedCount: 2 }, "the inserted ids reflect the new docs");
+      assert.deepEqual(mockInsertManyOk.mock.calls[0].arguments[0], [{ _id: "first-new", transformed: true }, { _id: "second-new", transformed: true }], "the underlying insertMany receives the totally-new docs");
+      assert.strictEqual(okAfterInsert.mock.callCount(), 2);
+      assert.deepEqual(okAfterInsert.mock.calls[0].arguments[0].doc, { _id: "first-new", transformed: true });
+      assert.deepEqual(okAfterInsert.mock.calls[0].arguments[0].docOrig, { _id: "first" });
+      assert.deepEqual(okAfterInsert.mock.calls[1].arguments[0].doc, { _id: "second-new", transformed: true });
+      assert.deepEqual(okAfterInsert.mock.calls[1].arguments[0].docOrig, { _id: "second" });
+
+      const { hookedCollection: hcErr, fakeCollection: fcErr } = getHookedCollection();
+      mock.method(fcErr, "insertMany", () => { throw new Error("BAD INSERT MANY"); });
+      hcErr.on("before.insert", ({ doc }) => ({ _id: `${doc._id}-new`, transformed: true }));
+      const errAfterInsert = mock.fn();
+      hcErr.on("after.insert.error", errAfterInsert);
+      hcErr.on("after.insert.success", () => assert.fail("after.insert.success must not fire on error"));
+      await assert.rejects(() => hcErr.insertMany([{ _id: "first" }, { _id: "second" }]), /BAD INSERT MANY/);
+      assert.strictEqual(errAfterInsert.mock.callCount(), 2);
+      assert.deepEqual(errAfterInsert.mock.calls[0].arguments[0].doc, { _id: "first-new", transformed: true }, "after.insert.error receives the new doc");
+      assert.deepEqual(errAfterInsert.mock.calls[0].arguments[0].docOrig, { _id: "first" });
+      assert.match(errAfterInsert.mock.calls[0].arguments[0].error.message, /BAD INSERT MANY/);
     });
 
     it("should use chained options instead of original options", async () => {

--- a/test/collection/insertMany.js
+++ b/test/collection/insertMany.js
@@ -6,7 +6,7 @@ import { assertImplements } from "../helpers.js";
 
 
 export function defineInsertMany() {
-  describe.only("insertMany", () => {
+  describe("insertMany", () => {
     it("should pass the options between before hooks correctly", async () => {
       const result = await hooksChain(
         "before.insertMany",
@@ -172,7 +172,7 @@ export function defineInsertMany() {
       assert.deepEqual(afterInsertMock.mock.calls[0].arguments[0].doc, { _id: "keepMe", a: 1, c: 1 }, "The non-skipped doc still flows through every transforming hook");
     });
 
-    it.only("after.* hooks should fire (success and error) when no before.* hooks are present", async () => {
+    it("after.* hooks should fire (success and error) when no before.* hooks are present", async () => {
       const { hookedCollection: hcOk } = getHookedCollection();
       const okAfterInsert = mock.fn();
       const okAfterInsertMany = mock.fn();

--- a/test/collection/insertOne.js
+++ b/test/collection/insertOne.js
@@ -90,6 +90,94 @@ export function defineInsertOne() {
       assert.deepEqual(result, { acknowledged: false, insertedId: null });
     });
 
+    it("Should skip documents correctly when multiple hooks are chained, even if a later hook returns a non-SkipDocument value", async () => {
+      const { hookedCollection, fakeCollection } = getHookedCollection();
+      const mockInsertOne = mock.method(fakeCollection, "insertOne");
+      const seenDocs = [];
+      hookedCollection.on("before.insert", ({ doc }) => {
+        seenDocs.push({ hook: "A", doc });
+        return { ...doc, a: 1 };
+      });
+      hookedCollection.on("before.insert", ({ doc }) => {
+        seenDocs.push({ hook: "B", doc });
+        return SkipDocument;
+      });
+      hookedCollection.on("before.insert", ({ doc, isSkipped }) => {
+        seenDocs.push({ hook: "C", doc, isSkipped });
+        return { ...doc, c: 1 };
+      });
+      hookedCollection.on("before.insert", ({ doc, isSkipped }) => {
+        seenDocs.push({ hook: "D", doc, isSkipped });
+      });
+      const afterInsertMock = mock.fn();
+      hookedCollection.on("after.insert.success", afterInsertMock);
+      const result = await hookedCollection.insertOne({ _id: "test" });
+      assert.strictEqual(seenDocs.length, 4, "All four before.insert hooks should run");
+      assert.deepEqual(seenDocs[0].doc, { _id: "test" }, "Hook A receives the original doc");
+      assert.deepEqual(seenDocs[1].doc, { _id: "test", a: 1 }, "Hook B receives the doc returned by Hook A");
+      assert.deepEqual(seenDocs[2].doc, { _id: "test", a: 1 }, "Hook C must not receive SkipDocument; it receives the previous chained value");
+      assert.deepEqual(seenDocs[3].doc, { _id: "test", a: 1, c: 1 }, "Hook D receives the value returned by Hook C, even though Hook B returned SkipDocument");
+      assert.deepEqual(seenDocs[2].isSkipped, true, "Hook C isSkipped");
+      assert.deepEqual(seenDocs[3].isSkipped, true, "Hook D isSkipped");
+      assert.strictEqual(mockInsertOne.mock.calls.length, 0, "The underlying insertOne must not be called when SkipDocument was returned");
+      assert.strictEqual(afterInsertMock.mock.callCount(), 0, "after.insert.success must not run when the document was skipped");
+      assert.deepEqual(result, { acknowledged: false, insertedId: null }, "The skip is respected even though a later hook returned a non-SkipDocument value");
+    });
+
+    it("after.* hooks should fire (success and error) when no before.* hooks are present", async () => {
+      const { hookedCollection: hcOk } = getHookedCollection();
+      const okAfterInsert = mock.fn();
+      const okAfterInsertOne = mock.fn();
+      hcOk.on("after.insert.success", okAfterInsert);
+      hcOk.on("after.insertOne.success", okAfterInsertOne);
+      hcOk.on("after.insert.error", () => assert.fail("after.insert.error must not fire on success"));
+      hcOk.on("after.insertOne.error", () => assert.fail("after.insertOne.error must not fire on success"));
+      await hcOk.insertOne({ _id: "ok" });
+      assert.strictEqual(okAfterInsert.mock.callCount(), 1, "after.insert.success fires without before hooks");
+      assert.strictEqual(okAfterInsertOne.mock.callCount(), 1, "after.insertOne.success fires without before hooks");
+
+      const { hookedCollection: hcErr, fakeCollection: fcErr } = getHookedCollection();
+      mock.method(fcErr, "insertOne", () => { throw new Error("BAD INSERT"); });
+      const errAfterInsert = mock.fn();
+      const errAfterInsertOne = mock.fn();
+      hcErr.on("after.insert.error", errAfterInsert);
+      hcErr.on("after.insertOne.error", errAfterInsertOne);
+      hcErr.on("after.insert.success", () => assert.fail("after.insert.success must not fire on error"));
+      hcErr.on("after.insertOne.success", () => assert.fail("after.insertOne.success must not fire on error"));
+      await assert.rejects(() => hcErr.insertOne({ _id: "fail" }), /BAD INSERT/);
+      assert.strictEqual(errAfterInsert.mock.callCount(), 1, "after.insert.error fires without before hooks");
+      assert.strictEqual(errAfterInsertOne.mock.callCount(), 1, "after.insertOne.error fires without before hooks");
+    });
+
+    it("after.insert hooks fire correctly (success and error) when before.insert returns a totally new object", async () => {
+      const { hookedCollection: hcOk, fakeCollection: fcOk } = getHookedCollection();
+      const mockInsertOk = mock.method(fcOk, "insertOne");
+      hcOk.on("before.insert", () => ({ _id: "transformed", brand: "new" }));
+      const okAfterInsert = mock.fn();
+      hcOk.on("after.insert.success", okAfterInsert);
+      hcOk.on("after.insert.error", () => assert.fail("after.insert.error must not fire on success"));
+
+      const result = await hcOk.insertOne({ _id: "original", legacy: true });
+      assert.deepEqual(result, { acknowledged: true, insertedId: "transformed" }, "the inserted id reflects the new doc");
+      assert.deepEqual(mockInsertOk.mock.calls[0].arguments[0], { _id: "transformed", brand: "new" }, "the underlying insertOne receives the totally-new doc");
+      assert.strictEqual(okAfterInsert.mock.callCount(), 1);
+      assert.deepEqual(okAfterInsert.mock.calls[0].arguments[0].doc, { _id: "transformed", brand: "new" }, "after.insert.success receives the new doc");
+      assert.deepEqual(okAfterInsert.mock.calls[0].arguments[0].docOrig, { _id: "original", legacy: true }, "after.insert.success still has access to the original doc via docOrig");
+      assert.deepEqual(okAfterInsert.mock.calls[0].arguments[0].result, { acknowledged: true, insertedId: "transformed" });
+
+      const { hookedCollection: hcErr, fakeCollection: fcErr } = getHookedCollection();
+      mock.method(fcErr, "insertOne", () => { throw new Error("BAD INSERT"); });
+      hcErr.on("before.insert", () => ({ _id: "transformed", brand: "new" }));
+      const errAfterInsert = mock.fn();
+      hcErr.on("after.insert.error", errAfterInsert);
+      hcErr.on("after.insert.success", () => assert.fail("after.insert.success must not fire on error"));
+      await assert.rejects(() => hcErr.insertOne({ _id: "original", legacy: true }), /BAD INSERT/);
+      assert.strictEqual(errAfterInsert.mock.callCount(), 1);
+      assert.deepEqual(errAfterInsert.mock.calls[0].arguments[0].doc, { _id: "transformed", brand: "new" }, "after.insert.error receives the new doc");
+      assert.deepEqual(errAfterInsert.mock.calls[0].arguments[0].docOrig, { _id: "original", legacy: true });
+      assert.match(errAfterInsert.mock.calls[0].arguments[0].error.message, /BAD INSERT/);
+    });
+
     it("should use chained options instead of original options", async () => {
       const { hookedCollection, fakeCollection } = getHookedCollection();
       const mockInsertOne = mock.method(fakeCollection, "insertOne");

--- a/test/collection/update.js
+++ b/test/collection/update.js
@@ -81,6 +81,50 @@ export function updateTests(oneOrMany) {
         });
       }
     });
+
+    it("Should skip documents correctly when multiple hooks are chained, even if a later hook returns a non-SkipDocument value", async () => {
+      const { hookedCollection } = getHookedCollection([{ _id: "test" }]);
+      const isReplace = oneOrMany.includes("eplace");
+      const callArgs = isReplace ? [{ _id: "test" }, { a: 1 }] : [{ _id: "test" }, { $set: { a: 1 } }];
+      const seenFilterMutators = [];
+      hookedCollection.on("before.update", ({ filterMutator }) => {
+        seenFilterMutators.push({ hook: "A", filterMutator });
+        return { ...filterMutator, filter: { ...filterMutator.filter, a: 1 } };
+      });
+      hookedCollection.on("before.update", ({ filterMutator }) => {
+        seenFilterMutators.push({ hook: "B", filterMutator });
+        return SkipDocument;
+      });
+      hookedCollection.on("before.update", ({ filterMutator, isSkipped }) => {
+        seenFilterMutators.push({ hook: "C", filterMutator, isSkipped });
+        return { ...filterMutator, filter: { ...filterMutator.filter, c: 1 } };
+      });
+      hookedCollection.on("before.update", ({ filterMutator, isSkipped }) => {
+        seenFilterMutators.push({ hook: "D", filterMutator, isSkipped });
+      });
+      const afterUpdateMock = mock.fn();
+      hookedCollection.on("after.update.success", afterUpdateMock);
+
+      const result = await hookedCollection[oneOrMany](...callArgs);
+
+      assert.strictEqual(seenFilterMutators.length, 4, "All four before.update hooks should run");
+      assert.deepEqual(seenFilterMutators[0].filterMutator.filter, { _id: "test" }, "Hook A receives the original filter");
+      assert.deepEqual(seenFilterMutators[1].filterMutator.filter, { _id: "test", a: 1 }, "Hook B receives the filter from Hook A");
+      assert.deepEqual(seenFilterMutators[2].filterMutator.filter, { _id: "test", a: 1 }, "Hook C must not receive SkipDocument; it receives the previous chained filterMutator");
+      assert.deepEqual(seenFilterMutators[3].filterMutator.filter, { _id: "test", a: 1, c: 1 }, "Hook D receives the filterMutator returned by Hook C even though Hook B returned SkipDocument");
+      assert.deepEqual(seenFilterMutators[2].isSkipped, true, "Hook C isSkipped");
+      assert.deepEqual(seenFilterMutators[3].isSkipped, true, "Hook D isSkipped");
+
+      assert.strictEqual(afterUpdateMock.mock.callCount(), 0, "after.update.success must not run when the document was skipped");
+      if (oneOrMany.startsWith("findOneAnd")) {
+        assert.deepEqual(result, { ok: 0, value: null }, "The skip is respected even though a later hook returned a non-SkipDocument value");
+      }
+      else {
+        assert.deepEqual(result, {
+          acknowledged: false, matchedCount: 1, modifiedCount: 0, upsertedCount: 0, upsertedId: null
+        }, "The skip is respected even though a later hook returned a non-SkipDocument value");
+      }
+    });
     it("Should greedily fetch the document if an after hook has fetchPrevious", async () => {
       const { hookedCollection } = getHookedCollection([{ _id: "test" }]);
       const afterUpdateMock = mock.fn();
@@ -148,6 +192,29 @@ export function updateTests(oneOrMany) {
           acknowledged: true, matchedCount: 1, modifiedCount: 1, upsertedCount: 0, upsertedId: null
         });
       }
+    });
+
+    it("after.* hooks should fire (success and error) when no before.* hooks are present", async () => {
+      const isReplace = oneOrMany.includes("eplace");
+      const isFindOneAnd = oneOrMany.startsWith("findOneAnd");
+      const perDocMethod = isFindOneAnd ? oneOrMany : (isReplace ? "replaceOne" : "updateOne");
+      const callArgs = isReplace ? [{ _id: "test" }, { a: 1 }] : [{ _id: "test" }, { $set: { a: 1 } }];
+
+      const { hookedCollection: hcOk } = getHookedCollection([{ _id: "test" }]);
+      const okAfterUpdate = mock.fn();
+      hcOk.on("after.update.success", okAfterUpdate);
+      hcOk.on("after.update.error", () => assert.fail("after.update.error must not fire on success"));
+      await hcOk[oneOrMany](...callArgs);
+      assert.strictEqual(okAfterUpdate.mock.callCount(), 1, "after.update.success fires without before hooks");
+
+      const { hookedCollection: hcErr, fakeCollection: fcErr } = getHookedCollection([{ _id: "test" }]);
+      mock.method(fcErr, perDocMethod, () => { throw new Error("BAD UPDATE"); });
+      const errAfterUpdate = mock.fn();
+      hcErr.on("after.update.error", errAfterUpdate);
+      hcErr.on("after.update.success", () => assert.fail("after.update.success must not fire on error"));
+      await assert.rejects(() => hcErr[oneOrMany](...callArgs));
+      assert.strictEqual(errAfterUpdate.mock.callCount(), 1, "after.update.error fires without before hooks");
+      assert.match(errAfterUpdate.mock.calls[0].arguments[0].error.message, /BAD UPDATE/);
     });
   });
 }


### PR DESCRIPTION
When a before insert/update/delete hook returns `SkipDocument` (allowing bulk operations to succeed while rejecting a single item), subsequent hooks would receive the SkipDocument instead of the actual document - causing them to fail.

the before hooks should always be called with the latest real document/filterMutator (and the original document if that's what they want) - the hooks will now receive an `isSkipped` boolean too, so they can decide to early abort if they want to.

after.* hooks will still only be called for documents that aren't skipped. 

While working on this some bugs were found:
1. `insertMany` when there are after hooks but no before hooks will fail
2. `insertMany` when a before hook returns a totally different document
3. `insert*/delete*/update*` after hooks: the doc argument was actually docOrig and docOrig was omitted. 